### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_nuget.yml
+++ b/.github/workflows/deploy_nuget.yml
@@ -1,4 +1,7 @@
 name: Deploy NuGet
+permissions:
+  contents: read
+  packages: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/jokk-itu/authserver-framework/security/code-scanning/2](https://github.com/jokk-itu/authserver-framework/security/code-scanning/2)

To fix the issue, we need to explicitly define the `permissions` block in the workflow. Since the workflow primarily interacts with repository contents (e.g., checking out code) and pushes packages to a NuGet registry, we should grant the minimal required permissions. Specifically:
- `contents: read` is needed for the `actions/checkout` step.
- `packages: write` is required for pushing packages to the NuGet registry.

The `permissions` block should be added at the workflow level to apply to all jobs, as there is only one job in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
